### PR TITLE
Fixes for NDK 20

### DIFF
--- a/decoder/jni/aac-decoder/Android.mk
+++ b/decoder/jni/aac-decoder/Android.mk
@@ -29,6 +29,7 @@ LOCAL_MODULE 			:= aacdecoder
 LOCAL_SRC_FILES 		:= aac-decoder.c
 LOCAL_CFLAGS 			:= $(cflags_loglevels)
 LOCAL_LDLIBS 			:= -llog
+LOCAL_DISABLE_FATAL_LINKER_WARNINGS := true
 LOCAL_STATIC_LIBRARIES 	:= decoder-opencore-aacdec decoder-opencore-mp3dec libpv_aac_dec libpv_mp3_dec
 include $(BUILD_SHARED_LIBRARY)
 

--- a/decoder/jni/opencore-aacdec/Android.mk
+++ b/decoder/jni/opencore-aacdec/Android.mk
@@ -43,7 +43,6 @@ LOCAL_SRC_FILES := \
  	src/get_adif_header.cpp \
  	src/get_adts_header.cpp \
  	src/get_audio_specific_config.cpp \
- 	src/get_cce.cpp \
  	src/get_dse.cpp \
  	src/get_ele_list.cpp \
  	src/get_ga_specific_config.cpp \
@@ -175,7 +174,7 @@ PV_CFLAGS :=
 # Unfortunately PS causes crash for certain streams:
 # fixed 2012-06-28
 #LOCAL_CFLAGS := -DAAC_PLUS -DHQ_SBR $(PV_CFLAGS)
-LOCAL_CFLAGS := -DAAC_PLUS -DHQ_SBR -DPARAMETRICSTEREO $(PV_CFLAGS)
+LOCAL_CFLAGS := -Wno-narrowing -DAAC_PLUS -DHQ_SBR -DPARAMETRICSTEREO $(PV_CFLAGS)
 
 ifeq ($(TARGET_ARCH),arm)
 	LOCAL_ARM_MODE := arm


### PR DESCRIPTION
It fixes two issues.

First one related to OpenCore coding style. They defined lots of constant tables as Int32, while values was used is bigger than Int32 max. Since it's just Int32 and UInt32 I've silenced this warning using `-Wno-narrowing`. Better solution would be to fix code in OpenCore.

Example:
```
/Users/evgen/git/aac/opencore/codecs_v2/audio/aac/dec/src/analysis_sub_band.cpp:108:18: error: constant expression evaluates to 4268654590 which cannot be narrowed to type 'Int32'
      (aka 'int') [-Wc++11-narrowing]
    0x07D97FC2,  0xFE6E7FFE, 0xF5057F87, 0xEBAB7E60,
                 ^~~~~~~~~~
```
Also there is no src/get_cce.cpp source file anymore and I just removed it from sources list.

Second issue is linker warning for armeabi-v7a:
```
[armeabi-v7a] SharedLibrary  : libaacdecoder.so
/Volumes/raid/android/ndk-bundle/toolchains/llvm/prebuilt/darwin-x86_64/bin/../lib/gcc/arm-linux-androideabi/4.9.x/../../../../arm-linux-androideabi/bin/ld: warning: shared library text segment is not shareable
/Volumes/raid/android/ndk-bundle/toolchains/llvm/prebuilt/darwin-x86_64/bin/../lib/gcc/arm-linux-androideabi/4.9.x/../../../../arm-linux-androideabi/bin/ld: error: treating warnings as errors
```
It was fixed by `LOCAL_DISABLE_FATAL_LINKER_WARNINGS := true`